### PR TITLE
Fix relative import in date utils

### DIFF
--- a/contest_trade/utils/date_utils.py
+++ b/contest_trade/utils/date_utils.py
@@ -1,5 +1,16 @@
+"""Utility functions for dealing with dates and trading calendars."""
+
 from datetime import datetime
-from utils.market_manager import GLOBAL_MARKET_MANAGER
+
+# ``date_utils`` lives inside the :mod:`contest_trade.utils` package. When it
+# was originally written it attempted to import ``GLOBAL_MARKET_MANAGER`` using
+# ``from utils.market_manager ...``. That works only when the project root is
+# added to ``sys.path`` manually, which isn't the case when the module is
+# imported as part of the package (e.g. ``import contest_trade.utils.date_utils``).
+# As a result a ``ModuleNotFoundError`` was raised. Using an explicit relative
+# import ensures the module works regardless of how the package is loaded.
+
+from .market_manager import GLOBAL_MARKET_MANAGER
 
 def get_current_datetime(trigger_time: str) -> str:
     """Get current time"""


### PR DESCRIPTION
## Summary
- fix `ModuleNotFoundError` in `date_utils` by using package-relative import for `GLOBAL_MARKET_MANAGER`
- document behavior and ensure file ends with newline

## Testing
- `pytest -q`
- `python -m contest_trade.utils.date_utils`


------
https://chatgpt.com/codex/tasks/task_e_68bdb290d5a88328833e702ee829a740